### PR TITLE
Fix "has no attribute 'keys' error"

### DIFF
--- a/math.py
+++ b/math.py
@@ -36,7 +36,6 @@ class MathExtension(markdown.extensions.Extension):
                 m.group(3) + m.group(4))
             return node
 
-        print (self.config)
         configs = self.getConfigs()
         inlinemathpatterns = (
             markdown.inlinepatterns.Pattern(r'(?<!\\|\$)(\$)([^\$]+)(\$)'),  #  $...$

--- a/math.py
+++ b/math.py
@@ -12,11 +12,13 @@ Author: 2015, Dmitry Shachnev <mitya57@gmail.com>.
 import markdown
 
 class MathExtension(markdown.extensions.Extension):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, configs=[]):
         self.config = {
             'enable_dollar_delimiter': [False, 'Enable single-dollar delimiter'],
         }
-        super(MathExtension, self).__init__(*args, **kwargs)
+
+        for key, value in configs:
+            self.setConfig(key, value)
 
     def extendMarkdown(self, md, md_globals):
         def handle_match_inline(m):
@@ -34,6 +36,7 @@ class MathExtension(markdown.extensions.Extension):
                 m.group(3) + m.group(4))
             return node
 
+        print (self.config)
         configs = self.getConfigs()
         inlinemathpatterns = (
             markdown.inlinepatterns.Pattern(r'(?<!\\|\$)(\$)([^\$]+)(\$)'),  #  $...$


### PR DESCRIPTION
This fixes a strange error I get for Python 3.4.1 as well as Python 2.7.8.

It only appears on one of three test machines, all of which have the exact same Python versions, as well as the exact same `uname -a`.

The error I get for Python 3 is:

      File "./nocms.py", line 78, in compile
        extension_configs=extension_configs)
      File "/usr/lib/python3.4/site-packages/markdown/__init__.py", line 410, in markdown
        md = Markdown(*args, **kwargs)
      File "/usr/lib/python3.4/site-packages/markdown/__init__.py", line 137, in __init__
        configs=kwargs.get('extension_configs', {}))
      File "/usr/lib/python3.4/site-packages/markdown/__init__.py", line 165, in registerExtensions
        ext.extendMarkdown(self, globals())
      File "/usr/lib/python3.4/site-packages/markdown/extensions/math.py", line 37, in extendMarkdown
        configs = self.getConfigs()
      File "/usr/lib/python3.4/site-packages/markdown/extensions/__init__.py", line 28, in getConfigs
        return dict([(key, self.getConfig(key)) for key in self.config.keys()])
    AttributeError: 'dict_items' object has no attribute 'keys'

For Python 2 I get:

    ** snip **
    AttributeError: 'list' object has no attribute 'keys'

The strangeness lies in the irreproducibility on two of three near-identical Fedora machines. Here's my `uname`:

    uname -a
    Linux desktop 3.17.7-300.fc21.x86_64 #1 SMP Wed Dec 17 03:08:44 UTC 2014 x86_64 x86_64 x86_64 GNU/Linux


Possibly there was some change in python-markdown, but it seems that at least the python files for /usr/lib/python/.../markdown/extensions/__init__.py are the same.



In any case, this Pull Request should fix the error.