### PR TITLE
Fix: Use self.getConfig to access a specific config value.

### DIFF
--- a/mdx_math.py
+++ b/mdx_math.py
@@ -34,7 +34,6 @@ class MathExtension(markdown.extensions.Extension):
                 node.text = markdown.util.AtomicString(m.group(3))
             return node
 
-        configs = self.getConfigs()
         inlinemathpatterns = (
             markdown.inlinepatterns.Pattern(r'(?<!\\|\$)(\$)([^\$]+)(\$)'),  #  $...$
             markdown.inlinepatterns.Pattern(r'(?<!\\)(\\\()(.+?)(\\\))')     # \(...\)
@@ -44,7 +43,7 @@ class MathExtension(markdown.extensions.Extension):
             markdown.inlinepatterns.Pattern(r'(?<!\\)(\\\[)(.+?)(\\\])'),    # \[...\]
             markdown.inlinepatterns.Pattern(r'(?<!\\)(\\begin{([a-z]+?\*?)})(.+?)(\\end{\3})')
         )
-        if not configs['enable_dollar_delimiter']:
+        if not self.getConfig('enable_dollar_delimiter'):
             inlinemathpatterns = inlinemathpatterns[1:]
         for i, pattern in enumerate(inlinemathpatterns):
             pattern.handleMatch = handle_match_inline


### PR DESCRIPTION
This fix allows this extension to work with python-markdown v2.4, which is what ships with Ubuntu 14 LTS. Without this fix, I see:

```
C:\blah>python -m markdown -x enki.plugins.preview.mdx_math
Traceback (most recent call last):
  File "C:\Python27\lib\runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "C:\Python27\lib\runpy.py", line 72, in _run_code
    exec code in run_globals
  File "C:\Python27\lib\site-packages\markdown\__main__.py", line 87, in <module>
    run()
  File "C:\Python27\lib\site-packages\markdown\__main__.py", line 81, in run
    markdown.markdownFromFile(**options)
  File "C:\Python27\lib\site-packages\markdown\__init__.py", line 438, in markdownFromFile
    md = Markdown(**kwargs)
  File "C:\Python27\lib\site-packages\markdown\__init__.py", line 137, in __init__
    configs=kwargs.get('extension_configs', {}))
  File "C:\Python27\lib\site-packages\markdown\__init__.py", line 165, in registerExtensions
    ext.extendMarkdown(self, globals())
  File "C:\Users\bjones\Documents\python-markdown-math\mdx_math.py", line 38, in extendMarkdown
  File "C:\Python27\lib\site-packages\markdown\extensions\__init__.py", line 28, in getConfigs
    return dict([(key, self.getConfig(key)) for key in self.config.keys()])
AttributeError: 'list' object has no attribute 'keys'
```