### PR TITLE
Add an option to render to span elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ The single-dollar delimiter (`$...$`) for inline math is disabled by
 default, but can be enabled by passing `enable_dollar_delimiter=True`
 in the extension configuration.
 
+If you want to render to span elements with inline math rather than script
+elements, so as to improve fallback when JavaScript is disabled or unavailable,
+use `render_to_span=True`.
+
 Notes
 -----
 

--- a/mdx_math.py
+++ b/mdx_math.py
@@ -15,14 +15,22 @@ class MathExtension(markdown.extensions.Extension):
     def __init__(self, *args, **kwargs):
         self.config = {
             'enable_dollar_delimiter': [False, 'Enable single-dollar delimiter'],
+            'render_to_span': [False,
+                'Render to span elements rather than script for fallback'],
         }
         super(MathExtension, self).__init__(*args, **kwargs)
 
     def extendMarkdown(self, md, md_globals):
         def handle_match_inline(m):
-            node = markdown.util.etree.Element('script')
-            node.set('type', 'math/tex')
-            node.text = markdown.util.AtomicString(m.group(3))
+            if self.getConfig('render_to_span'):
+                node = markdown.util.etree.Element('span')
+                node.set('class', 'tex')
+                node.text = ("\\\\(" + markdown.util.AtomicString(m.group(3)) +
+                        "\\\\)")
+            else:
+                node = markdown.util.etree.Element('script')
+                node.set('type', 'math/tex')
+                node.text = markdown.util.AtomicString(m.group(3))
             return node
 
         def handle_match(m):


### PR DESCRIPTION
I wanted to render MathJax to span elements so that it also works on browsers without JavaScript support or with JavaScript disabled, so I added an option to do this. Do you think it is reasonable to merge? Thanks!